### PR TITLE
create to fix issue #96, grunt hanging on Windows

### DIFF
--- a/lib/utils/getModulePaths.js
+++ b/lib/utils/getModulePaths.js
@@ -9,9 +9,9 @@ module.exports = function() {
       , args = [].slice.call(arguments);
 
     packageJson.bundledDependencies.forEach( function( name ) {
-    	var modulePath = [ 'modules', name ].concat( args ).join( path.sep );
-    	if ( fs.existsSync( modulePath ) || ( /(.*)+\/\*/.test( modulePath ) && fs.existsSync( RegExp.$1 + '/' ) ) ) {
-        	paths.push( modulePath );
+        var modulePath = [ 'modules', name ].concat( args ).join( path.sep );
+        if ( fs.existsSync( modulePath ) || fs.existsSync( path.dirname( modulePath ) ) ) {
+            paths.push( modulePath );
         }
     });
 


### PR DESCRIPTION
traced the hang to the regular expression evaluation.  Upon test being called, it locks up, and goes no further.  decided to use the path.dirname function, as we are requiring path anyway.  Copying this to my application created from 'clever init' stopped the hang
